### PR TITLE
Fixing #3859. Added help field in title tag for every textarea and input generated

### DIFF
--- a/include/SugarFields/Fields/Address/en_us.EditView.tpl
+++ b/include/SugarFields/Fields/Address/en_us.EditView.tpl
@@ -57,9 +57,9 @@
 </td>
 <td width="*">
 {{if $displayParams.maxlength}}
-<textarea id="{{$street}}" name="{{$street}}" maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{else}}
-<textarea id="{{$street}}" name="{{$street}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{/if}}
 </td>
 </tr>
@@ -73,7 +73,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$city}}" id="{{$city}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$city}}" id="{{$city}}" title='{$fields.{{$city}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -85,7 +85,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$state}}" id="{{$state}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$state}}" id="{{$state}}" title='{$fields.{{$state}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -99,7 +99,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" title='{$fields.{{$postalcode}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -113,7 +113,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$country}}" id="{{$country}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$country}}" id="{{$country}}" title='{$fields.{{$country}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 


### PR DESCRIPTION
NOTE: Replaces Pull request #3868, not being able to fix the errors in the pull request (I had to remove two files but messed it with git). I hope this unlocks these fix.

Description

Added title='{{$vardef.help}}', title='{$fields.{{$city}}.help}', title='{$fields.{{$state}}.help}'...
You set help for address fields in Studio but then is not displayed when you go into the EditView.

Motivation and Context

Displaying help text in address auto generated fields

How To Test This

You set help for account billing address and billing city. then you go to new account and mouse over billing address and billing city.

Types of changes
[X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[X] Breaking change (fix or feature that would cause existing functionality to change)

Final checklist
[X] My code follows the code style of this project found here.
[X] My change requires a change to the documentation.
[X] I have read the How to Contribute guidelines.-->