### PR TITLE
Remove Email Addresses from tracker

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -66,6 +66,9 @@ class SugarEmailAddress extends SugarBean
     const COI_STAT_OPT_IN = 'opt-in';
     const COI_STAT_CONFIRMED_OPT_IN = 'confirmed-opt-in';
 
+    /** @var boolean $tracker_visibility */
+    public $tracker_visibility = false;
+    
     /**
      * @var string $table_name
      */


### PR DESCRIPTION
## Description
Override Sugar bean variable $tracker_visibility to false

## Motivation and Context
Email addresses was being included in tracker table so it was being showed in "Recently viewed" in sidebar. This was fixed in Fix Base Implementation issue. #5411 but only by skipping them.

This caused the recently viewed feature to fail, showing less elements.

So I think the ultimate solution is keeping email addresses out of the tracker table.

## How To Test This
If you navigate contacts or accounts you see last five. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.