### PR TITLE
Fix unified search "no results" page

### DIFF
--- a/modules/Home/UnifiedSearch.php
+++ b/modules/Home/UnifiedSearch.php
@@ -93,6 +93,7 @@ if($queryString){
     <input id='searchFieldMain' class='searchField' type='text' size='80' name='query_string' placeholder='<?php echo translate("LBL_SEARCH_QUERY_PLACEHOLDER","AOD_Index");?>' value='<?php echo $queryString;?>'>
     <input type="submit" class="button primary" value="<?php echo translate("LBL_SEARCH_BUTTON","AOD_Index");?>">&nbsp;
 </form>
+<?php if($hits){ ?>
 <table cellpadding='0' cellspacing='0' width='100%' border='0' class='list View'>
     <?php getPaginateHTML($queryString, $start,$amount,$total); ?>
     <thead>
@@ -136,7 +137,6 @@ if($queryString){
     </tr>
     </thead>
     <?php
-    if($hits){
 foreach($hits as $hit){
     echo "<tr>"
         ."<td>".$hit->label."</td>"
@@ -147,11 +147,14 @@ foreach($hits as $hit){
         ."<td>".getScoreDisplay($hit)."</td>"
         ."</tr>";
 }
-        }else{
-        echo "<tr><td>".translate("LBL_SEARCH_RESULT_EMPTY","AOD_Index")."</td></td>";
-    }
 ?>
 </table>
+
+<?php
+        }else{
+        echo "<p>".translate("LBL_SEARCH_RESULT_EMPTY","AOD_Index")."</p>";
+    }
+?>
 
 <?php
 function getRecordSummary(SugarBean $bean){


### PR DESCRIPTION
## Description
The condition if $hits is moved before the <table> tag and the else after the </table>

The row and cell tags containing the No results messages are replaced by a paragraph tag.

## Motivation and Context
When you get no results in Unified Search you see a "broken" page with a useless table.
Results table should be shown only when there are, actually, results.
If no results are returned it should show just a message.

Now you get something like this (taken from Demo website):
![image](https://user-images.githubusercontent.com/23360/40918406-17fbf31c-67fe-11e8-8a0f-aa3318ff32d1.png)

After the fix you get this (taken from my SuiteCRM installation):
![image](https://user-images.githubusercontent.com/23360/40918457-38cd5be4-67fe-11e8-89a1-bc6fed45b277.png)


## How To Test This
Make a global search with PEPE. You get an "ugly" no results page.

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.